### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/hacker6i3q/ff6ec524-4801-420d-a8e2-213c944400d2/9e7c5b20-c8ad-4cdb-a908-8e7a7c4c32d7/_apis/work/boardbadge/6cd6a522-c3c3-44a1-96f4-1dbc210effdd)](https://dev.azure.com/hacker6i3q/ff6ec524-4801-420d-a8e2-213c944400d2/_boards/board/t/9e7c5b20-c8ad-4cdb-a908-8e7a7c4c32d7/Microsoft.RequirementCategory)
 # Tripviewer
 Repositório do tripviewer


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/hacker6i3q/ff6ec524-4801-420d-a8e2-213c944400d2/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.